### PR TITLE
Implement real-time chart data updates

### DIFF
--- a/src/components/event-detail/market-insight/chart-tab.tsx
+++ b/src/components/event-detail/market-insight/chart-tab.tsx
@@ -588,11 +588,6 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
         
         setLoading(false)
         
-        // Start real-time updates after global cached data load
-        setTimeout(() => {
-          startRealtimeUpdates()
-        }, 1000) // Start after 1 second
-        
         return
     }
 
@@ -632,11 +627,6 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
         }
         
         setLoading(false)
-        
-        // Start real-time updates after existing promise data load
-        setTimeout(() => {
-          startRealtimeUpdates()
-        }, 1000) // Start after 1 second
         
       } catch (error) {
         setError('Failed to load market data')
@@ -701,11 +691,6 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
         }
         
         setLoading(false)
-        
-        // Start real-time updates after cached data load
-        setTimeout(() => {
-          startRealtimeUpdates()
-        }, 1000) // Start after 1 second
         
         // Clean up active request marker for cached responses
         activeRequestsRef.current.delete(requestKey)
@@ -781,11 +766,6 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
       
       setLoading(false)
       
-      // Start real-time updates after initial data load
-      setTimeout(() => {
-        startRealtimeUpdates()
-      }, 1000) // Start after 1 second
-      
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred'
       setError(`Error loading market history: ${errorMessage}`)
@@ -794,7 +774,7 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
       // Always clean up the active request marker
       activeRequestsRef.current.delete(requestKey)
     }
-  }, [selectedMarket?.conditionId, selectedPeriod, calculateTimeRange, volumeType, getCachedData, setCachedData, startRealtimeUpdates])
+  }, [selectedMarket?.conditionId, selectedPeriod, calculateTimeRange, volumeType, getCachedData, setCachedData])
 
   // Real-time data fetch function
   const fetchRealtimeUpdate = useCallback(async () => {
@@ -960,6 +940,19 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
       activeRequestsRef.current.clear()
     }
   }, [selectedMarket?.conditionId, selectedPeriod, fetchMarketHistoryData])
+
+  // Start real-time updates after data loads and chart is ready
+  useEffect(() => {
+    if (!loading && rawDataRef.current.length > 0 && seriesRef.current && volumeSeriesRef.current && selectedMarket?.conditionId) {
+      const timeoutId = setTimeout(() => {
+        startRealtimeUpdates()
+      }, 1000) // Start after 1 second
+      
+      return () => {
+        clearTimeout(timeoutId)
+      }
+    }
+  }, [loading, selectedMarket?.conditionId, startRealtimeUpdates])
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/components/event-detail/market-insight/chart-tab.tsx
+++ b/src/components/event-detail/market-insight/chart-tab.tsx
@@ -817,11 +817,23 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
         const lastFive = rawDataRef.current.slice(-5)
         const existingIndex = lastFive.findIndex(point => point.timestamp === apiDataPoint.timestamp)
         
+        // Also check the ENTIRE array to see if timestamp exists elsewhere
+        const fullArrayIndex = rawDataRef.current.findIndex(point => point.timestamp === apiDataPoint.timestamp)
+        
         let actualIndex = -1
         if (existingIndex !== -1) {
           // Calculate actual index in the full array
           actualIndex = rawDataRef.current.length - 5 + existingIndex
         }
+        
+        console.log(`🔍 Timestamp ${apiDataPoint.timestamp} search:`, {
+          existsInLastFive: existingIndex !== -1,
+          existsInFullArray: fullArrayIndex !== -1,
+          lastFiveIndex: existingIndex,
+          fullArrayIndex: fullArrayIndex,
+          calculatedActualIndex: actualIndex,
+          arrayLength: rawDataRef.current.length
+        })
 
         if (actualIndex !== -1) {
           // Timestamp exists → UPDATE
@@ -836,9 +848,14 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
           console.log(`📈 Real-time: Updated datapoint at timestamp ${apiDataPoint.timestamp}`)
         } else {
           // Timestamp doesn't exist → INSERT
+          if (fullArrayIndex !== -1) {
+            console.log(`⚠️ WARNING: Timestamp ${apiDataPoint.timestamp} exists at index ${fullArrayIndex} but not found in last 5! This will create a duplicate.`)
+          }
+          
           console.log(`➕ About to INSERT datapoint:`, {
             timestamp: apiDataPoint.timestamp,
-            currentLastTimestamp: rawDataRef.current[rawDataRef.current.length - 1]?.timestamp
+            currentLastTimestamp: rawDataRef.current[rawDataRef.current.length - 1]?.timestamp,
+            willCreateDuplicate: fullArrayIndex !== -1
           })
           rawDataRef.current.push(apiDataPoint)
           volumeDataRef.current.push(apiDataPoint)

--- a/src/components/event-detail/market-insight/chart-tab.tsx
+++ b/src/components/event-detail/market-insight/chart-tab.tsx
@@ -793,11 +793,14 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
         return
       }
 
-      // Process each datapoint from API response (in order they appear)
+      // Sort datapoints by timestamp (oldest first) to avoid LightWeight Charts update order issues
+      const sortedDataPoints = [...result.data].sort((a, b) => a.timestamp - b.timestamp)
+      
+      // Process each datapoint in chronological order
       let updatedCount = 0
       let insertedCount = 0
 
-      for (const apiDataPoint of result.data) {
+      for (const apiDataPoint of sortedDataPoints) {
         // Check last 5 datapoints for existing timestamp
         const lastFive = rawDataRef.current.slice(-5)
         const existingIndex = lastFive.findIndex(point => point.timestamp === apiDataPoint.timestamp)
@@ -841,7 +844,7 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
         volumeSeriesRef.current.update(volumeData)
       }
 
-      console.log(`📈 Real-time: Processed ${result.data.length} datapoints (${updatedCount} updated, ${insertedCount} inserted)`)
+      console.log(`📈 Real-time: Processed ${sortedDataPoints.length} datapoints (${updatedCount} updated, ${insertedCount} inserted)`)
 
       // Clear any previous real-time errors
       setRealtimeError(null)
@@ -866,10 +869,10 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
     setRealtimeActive(true)
     setRealtimeError(null)
     
-    // Set interval for every minute (60000ms)
+    // Set interval for every 10 seconds (10000ms)
     realtimeIntervalRef.current = setInterval(() => {
       fetchRealtimeUpdate()
-    }, 60000) // 1 minute = 60000ms
+    }, 10000) // 10 seconds = 10000ms
 
     console.log('📈 Real-time updates started')
   }, [selectedMarket?.conditionId, fetchRealtimeUpdate])
@@ -1077,7 +1080,7 @@ export function ChartTab({ selectedMarket, selectedToken }: ChartTabProps) {
               <span>Live updates: {realtimeActive ? 'ON' : 'OFF'}</span>
             </div>
             {realtimeActive && (
-              <span className="text-green-600">• Updates every minute</span>
+              <span className="text-green-600">• Updates every 10 seconds</span>
             )}
           </div>
         </div>


### PR DESCRIPTION
Implement real-time chart updates with 10-second intervals and fix data ordering issues.

The "Cannot update oldest data" error from LightWeight Charts was due to real-time data being processed out of chronological order. Sorting the incoming API data by timestamp (oldest first) before applying updates resolves this, ensuring LightWeight Charts receives updates in the correct sequence.