### PR TITLE
Update missing price change display

### DIFF
--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -87,7 +87,7 @@ function MarketCard({ market, eventSlug, sortBy }: { market: Market & { eventTit
   }
   
   const formatVolume = (volume: number | null): string => {
-    if (volume === null || volume === 0) return '-'
+    if (volume === null || volume === 0) return '$0'
     if (volume >= 1000000) return `$${(volume / 1000000).toFixed(1)}M`
     if (volume >= 1000) return `$${(volume / 1000).toFixed(1)}K`
     return `$${volume.toFixed(0)}`
@@ -263,7 +263,7 @@ function EventCard({ event, sortBy }: { event: Event; sortBy: string }) {
   const [isOpen, setIsOpen] = useState(false)
 
   const formatVolume = (volume: number | null): string => {
-    if (!volume || volume === 0) return 'N/A'
+    if (!volume || volume === 0) return '$0'
     if (volume >= 1000000) return `$${(volume / 1000000).toFixed(1)}M`
     if (volume >= 1000) return `$${(volume / 1000).toFixed(1)}K`
     return `$${volume.toFixed(0)}`

--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -64,13 +64,13 @@ function MarketCard({ market, eventSlug, sortBy }: { market: Market & { eventTit
   }
   
   const formatPriceChange = (change: number | null): string => {
-    if (change === null) return '-'
+    if (change === null) return '+0.00'
     const sign = change >= 0 ? '+' : ''
     return `${sign}${(change * 100).toFixed(2)}`
   }
 
   const formatPercentagePrice = (change: number | null): string => {
-    if (change === null) return '-'
+    if (change === null) return '+0.00%'
     const sign = change >= 0 ? '+' : ''
     return `${sign}${(change * 100).toFixed(2)}%`
   }
@@ -82,7 +82,7 @@ function MarketCard({ market, eventSlug, sortBy }: { market: Market & { eventTit
   }
   
   const getPriceChangeColor = (change: number | null): string => {
-    if (change === null) return ''
+    if (change === null) return 'text-muted-foreground'
     return change >= 0 ? 'text-price-positive' : 'text-price-negative'
   }
   

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -358,19 +358,19 @@ function MarketCard({ market }: { market: MarketDisplay }) {
   }
   
   const formatPriceChange = (change: number | null): string => {
-    if (change === null) return '-'
+    if (change === null) return '+0.00'
     const sign = change >= 0 ? '+' : ''
     return `${sign}${(change * 100).toFixed(2)}`
   }
 
   const formatPercentagePrice = (change: number | null): string => {
-    if (change === null) return '-'
+    if (change === null) return '+0.00%'
     const sign = change >= 0 ? '+' : ''
     return `${sign}${(change * 100).toFixed(2)}%`
   }
   
   const getPriceChangeColor = (change: number | null): string => {
-    if (change === null) return ''
+    if (change === null) return 'text-muted-foreground'
     return change >= 0 ? 'text-price-positive' : 'text-price-negative'
   }
 


### PR DESCRIPTION
Replace '-' with '+0.00' and '+0.00%' for markets without price change data to improve display consistency.

---

[Open in Web](https://www.cursor.com/agents?id=bc-7d1193da-0868-48c0-a8ad-f51f4f1e56f9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7d1193da-0868-48c0-a8ad-f51f4f1e56f9)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)