### PR TITLE
Update event detail market history to use asset id

### DIFF
--- a/src/components/event-detail/market-insight/holder-card.tsx
+++ b/src/components/event-detail/market-insight/holder-card.tsx
@@ -13,7 +13,8 @@ import { TradeHistoryDialog } from './trade-history-dialog'
 // Holder Card Component
 export function HolderCard({ 
   holder, 
-  selectedMarket, 
+  selectedMarket,
+  selectedToken,
   formatShares, 
   getDefaultAvatar 
 }: HolderCardProps) {
@@ -89,6 +90,7 @@ export function HolderCard({
               <TradeHistoryDialog 
                 holder={holder} 
                 selectedMarket={selectedMarket}
+                selectedToken={selectedToken}
               />
             </DialogContent>
           </Dialog>

--- a/src/components/event-detail/market-insight/trade-chart.tsx
+++ b/src/components/event-detail/market-insight/trade-chart.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Loader2, BarChart3 } from 'lucide-react'
 import { createChart, IChartApi, ISeriesApi, CandlestickSeries, HistogramSeries, ColorType } from 'lightweight-charts'
-import { TradeChartProps, TimePeriod, MarketHistoryResponse, MarketHistoryDataPoint } from './types'
+import { TradeChartProps, TimePeriod, MarketHistoryResponse, MarketHistoryDataPoint, getAssetIdFromMarket } from './types'
 
 // Trade Chart Component - Real integration with LightweightCharts
 export function TradeChart({ 
@@ -10,6 +10,7 @@ export function TradeChart({
   error, 
   holder, 
   selectedMarket,
+  selectedToken,
   selectedPeriod = '1h'
 }: TradeChartProps) {
   const chartContainerRef = useRef<HTMLDivElement>(null)
@@ -23,8 +24,9 @@ export function TradeChart({
 
   // Fetch market history data for the chart
   const fetchMarketHistory = useCallback(async () => {
-    if (!selectedMarket?.conditionId) {
-      setChartError('No market selected')
+    const assetId = getAssetIdFromMarket(selectedMarket, selectedToken)
+    if (!assetId) {
+      setChartError('No market selected or asset data unavailable')
       return
     }
 
@@ -37,7 +39,7 @@ export function TradeChart({
       const startTs = now - (14 * 24 * 3600)
       const fidelity = 60 // 1 hour intervals
 
-      const url = `https://trade-analyze-production.up.railway.app/api/market-history?market=${encodeURIComponent(selectedMarket.conditionId)}&startTs=${startTs}&endTs=${now}&fidelity=${fidelity}`
+      const url = `https://trade-analyze-production.up.railway.app/api/market-history?asset_id=${encodeURIComponent(assetId)}&startTs=${startTs}&endTs=${now}&fidelity=${fidelity}`
       
       const response = await fetch(url)
       
@@ -58,7 +60,7 @@ export function TradeChart({
     } finally {
       setChartLoading(false)
     }
-  }, [selectedMarket?.conditionId])
+  }, [selectedMarket, selectedToken])
 
   // Initialize chart
   useEffect(() => {

--- a/src/components/event-detail/market-insight/trade-history-dialog.tsx
+++ b/src/components/event-detail/market-insight/trade-history-dialog.tsx
@@ -8,7 +8,8 @@ import { TradeChart } from './trade-chart'
 // Trade History Dialog Component  
 export function TradeHistoryDialog({ 
   holder, 
-  selectedMarket 
+  selectedMarket,
+  selectedToken
 }: TradeHistoryDialogProps) {
   const [allTrades, setAllTrades] = useState<any[]>([])
   const [loading, setLoading] = useState(false)
@@ -90,6 +91,7 @@ export function TradeHistoryDialog({
           error={error}
           holder={holder}
           selectedMarket={selectedMarket}
+          selectedToken={selectedToken}
           selectedPeriod="1h"
         />
       </div>

--- a/src/components/event-detail/market-insight/trader-analysis.tsx
+++ b/src/components/event-detail/market-insight/trader-analysis.tsx
@@ -176,6 +176,7 @@ export function TraderAnalysis({ selectedMarket }: TraderAnalysisProps) {
                   key={`yes-${holderIndex}`} 
                   holder={holder} 
                   selectedMarket={selectedMarket}
+                  selectedToken="yes"
                   formatShares={formatShares}
                   getDefaultAvatar={getDefaultAvatar}
                 />
@@ -198,6 +199,7 @@ export function TraderAnalysis({ selectedMarket }: TraderAnalysisProps) {
                   key={`no-${holderIndex}`} 
                   holder={holder} 
                   selectedMarket={selectedMarket}
+                  selectedToken="no"
                   formatShares={formatShares}
                   getDefaultAvatar={getDefaultAvatar}
                 />

--- a/src/components/event-detail/market-insight/types.ts
+++ b/src/components/event-detail/market-insight/types.ts
@@ -9,7 +9,7 @@ export interface MarketInsightCardProps {
 
 // New interface for market history API response
 export interface MarketHistoryResponse {
-  market: string
+  asset_id: string
   start: number
   fidelity: number
   data: MarketHistoryDataPoint[]
@@ -96,17 +96,20 @@ export interface TradeChartProps {
   error: string | null
   holder: any
   selectedMarket: Market | null
+  selectedToken: 'yes' | 'no'
   selectedPeriod?: TimePeriod
 }
 
 export interface TradeHistoryDialogProps {
   holder: any
   selectedMarket: Market | null
+  selectedToken: 'yes' | 'no'
 }
 
 export interface HolderCardProps {
   holder: any
   selectedMarket: Market | null
+  selectedToken: 'yes' | 'no'
   formatShares: (amount: number) => string
   getDefaultAvatar: (name: string) => string
 }
@@ -119,4 +122,23 @@ export interface ChartTabProps {
 
 export interface InfoTabProps {
   selectedMarket: Market | null
+}
+
+// Helper function to extract asset_id from market based on selected token
+export const getAssetIdFromMarket = (market: Market | null, selectedToken: 'yes' | 'no'): string | null => {
+  if (!market?.clobTokenIds) {
+    return null
+  }
+  
+  try {
+    const tokenIds = JSON.parse(market.clobTokenIds)
+    if (Array.isArray(tokenIds) && tokenIds.length >= 2) {
+      // tokenIds[0] is YES token, tokenIds[1] is NO token
+      return selectedToken === 'yes' ? tokenIds[0] : tokenIds[1]
+    }
+  } catch (error) {
+    console.error('Failed to parse clobTokenIds:', error)
+  }
+  
+  return null
 } 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update market history API calls to use `asset_id` derived from the selected token instead of `conditionId`.

---
<a href="https://cursor.com/background-agent?bcId=bc-24873504-e02a-49f8-a465-320812494b9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24873504-e02a-49f8-a465-320812494b9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>