### PR TITLE
Use market closed time for price chart

### DIFF
--- a/src/components/event-detail/trading-activity-card.tsx
+++ b/src/components/event-detail/trading-activity-card.tsx
@@ -50,15 +50,6 @@ interface TradingActivityCardProps {
 let globalRefreshInterval: NodeJS.Timeout | null = null
 const globalRefreshCallbacks = new Map<string, () => void>()
 
-// Global data cache to prevent duplicate API calls from multiple component instances
-const globalDataCache = new Map<string, {
-  marketTrades: ProcessedTrade[]
-  userTrades: ProcessedTrade[]
-  marketPagination: any
-  userPagination: any
-  timestamp: number
-}>()
-
 // Global active API requests to prevent duplicate concurrent calls
 const globalActiveRequests = new Set<string>()
 


### PR DESCRIPTION
Display price charts for resolved markets using their `closedTime` as the end timestamp and disable real-time updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-44ecf80a-f597-49d3-86df-ff834cc6f985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44ecf80a-f597-49d3-86df-ff834cc6f985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>