### PR TITLE
Optimize market list client-side sorting

### DIFF
--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -577,7 +577,9 @@ export default function MarketsPage() {
     isError: eventsError,
     error: eventsErrorDetails,
   } = useQuery<EventsResponse>({
-    queryKey: ['all-events', debouncedSearchTerm, eventStatus, viewMode, selectedTag, minPrice, maxPrice, minBestAsk, maxBestAsk, sortBy, sortDirection, currentPage],
+    queryKey: eventStatus === 'active' 
+      ? ['all-events', debouncedSearchTerm, eventStatus, viewMode, selectedTag] // Active mode: only essential params that require new data
+      : ['all-events', debouncedSearchTerm, eventStatus, viewMode, selectedTag, minPrice, maxPrice, minBestAsk, maxBestAsk, sortBy, sortDirection, currentPage], // Closed mode: all params for server-side processing
     queryFn: async () => {
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), API_CONFIG.TIMEOUTS.DEFAULT)


### PR DESCRIPTION
Prevent unnecessary API calls in active market mode by adjusting React Query's `queryKey` to enable client-side sorting and filtering.

Previously, in 'active' mode, changing sort or certain filter options (like price ranges) caused React Query to re-fetch all market data from the API. This was inefficient as the application is designed to fetch all active events once (`limit=9999`) and then handle sorting and filtering client-side. This change modifies the `queryKey` to exclude these parameters when `eventStatus` is 'active', ensuring that only truly new data requirements trigger an API call, while client-side logic handles the rest.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5f96c08-97fc-4ce6-b3de-7f8e296f0497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5f96c08-97fc-4ce6-b3de-7f8e296f0497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

