### PR TITLE
Update closed market sorting and UI display

### DIFF
--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, startTransition } from 'react'
+import { useState, useEffect, startTransition, flushSync } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -1016,13 +1016,29 @@ export default function MarketsPage() {
     // Note: viewMode and eventStatus are preserved
   }
 
-  // Reset filters when switching between active/closed status
+  // Reset filters when switching between active/closed status  
   useEffect(() => {
     console.log('🔄 eventStatus changed to:', eventStatus)
-    console.log('🔄 Setting isResettingForStatusChange to TRUE')
-    setIsResettingForStatusChange(true)
-    resetFiltersForStatusChange()
-    // Reset flag after state updates complete
+    
+    // First, synchronously set the flag to disable React Query
+    flushSync(() => {
+      console.log('🔄 Setting isResettingForStatusChange to TRUE (sync)')
+      setIsResettingForStatusChange(true)
+    })
+    
+    // Then update all other states
+    console.log('🔄 Resetting all filter states')
+    setSearchTerm('')
+    setSelectedTag('all')
+    setMinPrice('')
+    setMaxPrice('')
+    setMinBestAsk('')
+    setMaxBestAsk('')
+    setSortBy(getDefaultSort(viewMode, eventStatus))
+    setSortDirection('desc')
+    setCurrentPage(1)
+    
+    // Reset flag after all updates complete
     setTimeout(() => {
       console.log('🔄 Setting isResettingForStatusChange to FALSE')
       setIsResettingForStatusChange(false)

--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, startTransition } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -584,7 +584,7 @@ export default function MarketsPage() {
   } = useQuery<EventsResponse>({
     queryKey: eventStatus === 'active' 
       ? ['all-events', debouncedSearchTerm, eventStatus, viewMode, selectedTag] // Active mode: only essential params that require new data
-      : ['all-events', debouncedSearchTerm, eventStatus, viewMode, selectedTag, minPrice, maxPrice, minBestAsk, maxBestAsk, sortBy, sortDirection, currentPage], // Closed mode: all params for server-side processing
+      : ['all-events', eventStatus, viewMode, debouncedSearchTerm, selectedTag, sortBy, sortDirection, currentPage], // Closed mode: stable order, excluding price filters since they're not supported
     queryFn: async () => {
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), API_CONFIG.TIMEOUTS.DEFAULT)
@@ -989,7 +989,9 @@ export default function MarketsPage() {
 
   // Reset filters when switching between active/closed status
   useEffect(() => {
-    resetFiltersForStatusChange()
+    startTransition(() => {
+      resetFiltersForStatusChange()
+    })
   }, [eventStatus])
 
   // Reset to page 1 when filters change

--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -581,7 +581,7 @@ export default function MarketsPage() {
     ? ['all-events', debouncedSearchTerm, eventStatus, viewMode, selectedTag] // Active mode: only essential params that require new data
     : ['all-events', eventStatus, viewMode, debouncedSearchTerm, selectedTag, sortBy, sortDirection, currentPage] // Closed mode: stable order, excluding price filters since they're not supported
   
-  console.log('🔑 Query key:', JSON.stringify(queryKey))
+  console.log('🔑 Query key:', JSON.stringify(queryKey), 'enabled:', !isResettingForStatusChange)
   
   const {
     data: allEventsData,
@@ -673,6 +673,7 @@ export default function MarketsPage() {
     retry: 1,
     staleTime: 30 * 1000,
     gcTime: 60 * 1000,
+    enabled: !isResettingForStatusChange,
   })
 
   // Process markets from events for Markets view mode

--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -498,6 +498,7 @@ export default function MarketsPage() {
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
   const [isFiltersOpen, setIsFiltersOpen] = useState(false)
   const [currentPage, setCurrentPage] = useState<number>(1)
+  const [isResettingForStatusChange, setIsResettingForStatusChange] = useState(false)
 
   const itemsPerPage = 20
 
@@ -998,14 +999,22 @@ export default function MarketsPage() {
   // Reset filters when switching between active/closed status
   useEffect(() => {
     console.log('🔄 eventStatus changed to:', eventStatus)
+    setIsResettingForStatusChange(true)
     resetFiltersForStatusChange()
+    // Reset flag after state updates complete
+    setTimeout(() => setIsResettingForStatusChange(false), 0)
   }, [eventStatus])
 
   // Reset to page 1 when filters change
   useEffect(() => {
+    // Skip if we're currently resetting due to status change
+    if (isResettingForStatusChange) {
+      console.log('📄 Skipping currentPage reset - status change in progress')
+      return
+    }
     console.log('📄 Resetting currentPage to 1 due to filter changes')
     setCurrentPage(1)
-  }, [debouncedSearchTerm, selectedTag, minPrice, maxPrice, minBestAsk, maxBestAsk, sortBy, sortDirection])
+  }, [debouncedSearchTerm, selectedTag, minPrice, maxPrice, minBestAsk, maxBestAsk, sortBy, sortDirection, isResettingForStatusChange])
 
   return (
     <div className="min-h-screen bg-background">

--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -293,7 +293,7 @@ function MarketCard({ market, eventSlug, sortBy, isClosed = false }: { market: M
           )}
           <div className="w-24 text-right">
             <div className="text-xs text-muted-foreground mb-1">{isClosed ? 'Volume' : '24h Volume'}</div>
-            <div className="font-medium">{formatVolume(isClosed ? (market.volume || market.volume24hr) : market.volume24hr || null)}</div>
+            <div className="font-medium">{formatVolume(isClosed ? (market.volume || market.volume24hr || null) : (market.volume24hr || null))}</div>
           </div>
         </div>
 
@@ -428,10 +428,15 @@ function EventCard({ event, sortBy, isClosed = false }: { event: Event; sortBy: 
                       <div className="font-medium">{formatVolume(displayVolume)}</div>
                     </div>
 
-                    {!isClosed && (
+                    {!isClosed ? (
                       <div className="text-center">
                         <div className="text-xs text-muted-foreground mb-1">Ends</div>
                         <div className="font-medium">{formatDate(event.endDate)}</div>
+                      </div>
+                    ) : (
+                      <div className="text-center">
+                        <div className="text-xs text-muted-foreground mb-1">Closed</div>
+                        <div className="font-medium">{formatDate(event.closedTime || event.closed_time || event.endDate)}</div>
                       </div>
                     )}
                   </div>
@@ -608,12 +613,12 @@ export default function MarketsPage() {
           
           // Map frontend sort options to API sort parameters
           const getApiSortParams = (sortBy: string, sortDirection: string) => {
-            let order = 'endDate' // Default order
+            let order = 'closed_time' // Default order for closed events
             
             if (sortBy === 'volume24hr' || sortBy === 'volume1wk' || sortBy === 'liquidity' || sortBy === 'volume') {
               order = 'volume'
             } else if (sortBy === 'endDate') {
-              order = 'endDate'
+              order = 'closed_time'
             }
             
             return {
@@ -796,8 +801,8 @@ export default function MarketsPage() {
             comparison = a.title.localeCompare(b.title)
             break
           case 'endDate':
-              const aEndDate = a.endDate || '2099-12-31'
-              const bEndDate = b.endDate || '2099-12-31'
+              const aEndDate = a.closedTime || a.closed_time || a.endDate || '2099-12-31'
+              const bEndDate = b.closedTime || b.closed_time || b.endDate || '2099-12-31'
               comparison = new Date(aEndDate).getTime() - new Date(bEndDate).getTime()
             break
           default:
@@ -1194,7 +1199,7 @@ export default function MarketsPage() {
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value="volume">Volume</SelectItem>
-                          <SelectItem value="endDate">End Date</SelectItem>
+                          <SelectItem value="endDate">Closed Time</SelectItem>
                         </SelectContent>
                       </Select>
                       <Button
@@ -1268,7 +1273,7 @@ export default function MarketsPage() {
                 ) : (
                   <>
                     Showing {startIndex + 1}-{Math.min(endIndex, total)} of {total} {eventStatus} events
-                    {allEventsData && ` (${allEventsData.events.length} total)`}
+                    {allEventsData?.events && ` (${allEventsData.events.length} total)`}
                   </>
                 )}
               </div>
@@ -1404,7 +1409,7 @@ export default function MarketsPage() {
                           </SelectTrigger>
                           <SelectContent>
                             <SelectItem value="volume">Volume</SelectItem>
-                            <SelectItem value="endDate">End Date</SelectItem>
+                            <SelectItem value="endDate">Closed Time</SelectItem>
                           </SelectContent>
                         </Select>
                         <Button

--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -499,6 +499,21 @@ export default function MarketsPage() {
   const [isFiltersOpen, setIsFiltersOpen] = useState(false)
   const [currentPage, setCurrentPage] = useState<number>(1)
   const [isResettingForStatusChange, setIsResettingForStatusChange] = useState(false)
+  
+  // Debug: Log when isResettingForStatusChange changes
+  useEffect(() => {
+    console.log('🚩 isResettingForStatusChange changed to:', isResettingForStatusChange)
+  }, [isResettingForStatusChange])
+  
+  // Debug: Log when sortBy changes
+  useEffect(() => {
+    console.log('🎯 sortBy changed to:', sortBy)
+  }, [sortBy])
+  
+  // Debug: Log when eventStatus changes
+  useEffect(() => {
+    console.log('📋 eventStatus state changed to:', eventStatus)
+  }, [eventStatus])
 
   const itemsPerPage = 20
 
@@ -581,7 +596,7 @@ export default function MarketsPage() {
     ? ['all-events', debouncedSearchTerm, eventStatus, viewMode, selectedTag] // Active mode: only essential params that require new data
     : ['all-events', eventStatus, viewMode, debouncedSearchTerm, selectedTag, sortBy, sortDirection, currentPage] // Closed mode: stable order, excluding price filters since they're not supported
   
-  console.log('🔑 Query key:', JSON.stringify(queryKey), 'enabled:', !isResettingForStatusChange)
+  console.log('🔑 Query key:', JSON.stringify(queryKey), 'enabled:', !isResettingForStatusChange, 'isResettingForStatusChange:', isResettingForStatusChange)
   
   const {
     data: allEventsData,
@@ -591,7 +606,7 @@ export default function MarketsPage() {
   } = useQuery<EventsResponse>({
     queryKey: queryKey,
     queryFn: async () => {
-      console.log('🌐 API Request triggered for eventStatus:', eventStatus, 'sortBy:', sortBy, 'viewMode:', viewMode)
+      console.log('🌐 API Request STARTED for eventStatus:', eventStatus, 'sortBy:', sortBy, 'viewMode:', viewMode, 'isResettingForStatusChange:', isResettingForStatusChange)
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), API_CONFIG.TIMEOUTS.DEFAULT)
       
@@ -983,6 +998,7 @@ export default function MarketsPage() {
   // Reset filters when switching between active/closed status
   const resetFiltersForStatusChange = () => {
     console.log('🧹 resetFiltersForStatusChange called for eventStatus:', eventStatus, 'viewMode:', viewMode)
+    console.log('🧹 Current sortBy before reset:', sortBy)
     setSearchTerm('')
     setSelectedTag('all')
     setMinPrice('')
@@ -990,20 +1006,27 @@ export default function MarketsPage() {
     setMinBestAsk('')
     setMaxBestAsk('')
     const newSort = getDefaultSort(viewMode, eventStatus)
-    console.log('📊 Setting sortBy to:', newSort)
+    console.log('📊 Setting sortBy from', sortBy, 'to:', newSort)
     setSortBy(newSort)
+    console.log('📊 Setting sortDirection to: desc')
     setSortDirection('desc')
+    console.log('📊 Setting currentPage to: 1')
     setCurrentPage(1)
+    console.log('🧹 resetFiltersForStatusChange completed')
     // Note: viewMode and eventStatus are preserved
   }
 
   // Reset filters when switching between active/closed status
   useEffect(() => {
     console.log('🔄 eventStatus changed to:', eventStatus)
+    console.log('🔄 Setting isResettingForStatusChange to TRUE')
     setIsResettingForStatusChange(true)
     resetFiltersForStatusChange()
     // Reset flag after state updates complete
-    setTimeout(() => setIsResettingForStatusChange(false), 0)
+    setTimeout(() => {
+      console.log('🔄 Setting isResettingForStatusChange to FALSE')
+      setIsResettingForStatusChange(false)
+    }, 0)
   }, [eventStatus])
 
   // Reset to page 1 when filters change

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -8,6 +8,8 @@ export interface Event {
   slug: string
   startDate: string
   endDate: string
+  closedTime?: string
+  closed_time?: string
   volume?: number
   volume24hr?: number
   volume1wk?: number


### PR DESCRIPTION
Align closed market sorting, API requests, and display with 'Closed Time' instead of 'End Date'.

---
<a href="https://cursor.com/background-agent?bcId=bc-72024eda-f164-4b83-bdde-123ca60fab69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72024eda-f164-4b83-bdde-123ca60fab69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

