### PR TITLE
Update market list page event status

### DIFF
--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -531,7 +531,7 @@ export default function MarketsPage() {
   // Get default sort option for each view mode and status
   const getDefaultSort = (mode: 'markets' | 'events', status: 'active' | 'closed' = 'active'): string => {
     if (status === 'closed') {
-      return 'volume' // Default to volume for closed events/markets
+      return 'endDate' // Default to closed_time for closed events/markets
     }
     return mode === 'markets' ? 'volume24hr' : 'volume24hr'
   }

--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -1126,6 +1126,10 @@ export default function MarketsPage() {
                 {tag}
               </Button>
             ))}
+            {/* Multiple Select Indicator */}
+            <span className="text-xs text-muted-foreground whitespace-nowrap ml-2">
+              multi-select
+            </span>
           </div>
         </div>
       </div>
@@ -1285,22 +1289,24 @@ export default function MarketsPage() {
                   </div>
                 )}
 
-                {/* Advanced Filters Group */}
-                <div className="space-y-3">
-                  <h3 className="text-sm font-semibold text-muted-foreground">ADVANCED FILTERS</h3>
-                  <div className="space-y-2">
-                    <Select value={minVolume} onValueChange={setMinVolume}>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder="Minimum Volume" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="100">Above $100</SelectItem>
-                        <SelectItem value="1000">Above $1K</SelectItem>
-                        <SelectItem value="1000000">Above $1M</SelectItem>
-                      </SelectContent>
-                    </Select>
+                {/* Advanced Filters Group - Only show for active events */}
+                {eventStatus === 'active' && (
+                  <div className="space-y-3">
+                    <h3 className="text-sm font-semibold text-muted-foreground">ADVANCED FILTERS</h3>
+                    <div className="space-y-2">
+                      <Select value={minVolume} onValueChange={setMinVolume}>
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Minimum Volume" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="100">Above $100</SelectItem>
+                          <SelectItem value="1000">Above $1K</SelectItem>
+                          <SelectItem value="1000000">Above $1M</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
                   </div>
-                </div>
+                )}
 
                 {/* Sort Options Group */}
                 <div className="space-y-3">
@@ -1512,22 +1518,24 @@ export default function MarketsPage() {
                     </div>
                   )}
 
-                  {/* Advanced Filters */}
-                  <div className="space-y-2">
-                    <h3 className="text-sm font-semibold text-muted-foreground">ADVANCED FILTERS</h3>
+                  {/* Advanced Filters - Only show for active events */}
+                  {eventStatus === 'active' && (
                     <div className="space-y-2">
-                      <Select value={minVolume} onValueChange={setMinVolume}>
-                        <SelectTrigger className="w-full">
-                          <SelectValue placeholder="Minimum Volume" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="100">Above $100</SelectItem>
-                          <SelectItem value="1000">Above $1K</SelectItem>
-                          <SelectItem value="1000000">Above $1M</SelectItem>
-                        </SelectContent>
-                      </Select>
+                      <h3 className="text-sm font-semibold text-muted-foreground">ADVANCED FILTERS</h3>
+                      <div className="space-y-2">
+                        <Select value={minVolume} onValueChange={setMinVolume}>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Minimum Volume" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="100">Above $100</SelectItem>
+                            <SelectItem value="1000">Above $1K</SelectItem>
+                            <SelectItem value="1000000">Above $1M</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
                     </div>
-                  </div>
+                  )}
 
                   {/* Sort */}
                   <div className="space-y-2">

--- a/src/components/ui/events-data-table.tsx
+++ b/src/components/ui/events-data-table.tsx
@@ -266,7 +266,9 @@ export function EventsDataTable({ data }: EventsDataTableProps) {
       accessorKey: "endDate",
       header: "End Date",
       cell: ({ row }) => {
-        const date = row.getValue("endDate") as string
+        const event = row.original
+        // Use closedTime if available, fallback to closed_time, then endDate
+        const date = event.closedTime || event.closed_time || event.endDate
         return <div>{formatDate(date)}</div>
       },
       enableSorting: false,


### PR DESCRIPTION
Update the events data table to display `closedTime` or `closed_time` for closed events instead of `endDate`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6e44ed2-f911-4e89-94fd-eaf56f6045e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6e44ed2-f911-4e89-94fd-eaf56f6045e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

