### PR TITLE
Update market list closed status display

### DIFF
--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -128,6 +128,12 @@ function MarketCard({ market, eventSlug, sortBy, isClosed = false }: { market: M
       const diffInMs = date.getTime() - now.getTime()
       const diffInDays = Math.ceil(diffInMs / (1000 * 60 * 60 * 24))
       
+      // For past dates (closed events), always show the actual date
+      if (diffInMs < 0) {
+        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+      }
+      
+      // For future dates (active events)
       if (diffInDays < 1) return 'Today'
       if (diffInDays === 1) return '1 day'
       if (diffInDays < 7) return `${diffInDays} days`
@@ -341,6 +347,12 @@ function EventCard({ event, sortBy, isClosed = false }: { event: Event; sortBy: 
       const diffInMs = date.getTime() - now.getTime()
       const diffInDays = Math.ceil(diffInMs / (1000 * 60 * 60 * 24))
       
+      // For past dates (closed events), always show the actual date
+      if (diffInMs < 0) {
+        return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+      }
+      
+      // For future dates (active events)
       if (diffInDays < 1) return 'Today'
       if (diffInDays === 1) return '1 day'
       if (diffInDays < 7) return `${diffInDays} days`


### PR DESCRIPTION
Fixes incorrect 'Today' display for past `closedTime` in market and event cards by showing the actual date.

The `formatDate` function's logic for relative time (e.g., "Today", "1 day") was designed for future dates. When a past `closedTime` was passed, the time difference calculation resulted in a negative value, which `Math.ceil` then rounded up, causing the "Today" condition to be met. This PR adds a check for negative time differences to explicitly format past dates.

---
<a href="https://cursor.com/background-agent?bcId=bc-63e42f65-7905-465a-9f7a-ffb74bd557ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63e42f65-7905-465a-9f7a-ffb74bd557ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

