### PR TITLE
Add esports tag to market list

### DIFF
--- a/src/app/markets/page.tsx
+++ b/src/app/markets/page.tsx
@@ -62,7 +62,7 @@ interface TagsResponse {
 
 // Predefined tags list (matching the navigation style)
 const PREDEFINED_TAGS = [
-  'Politics', 'Middle East', 'Sports', 'Crypto',
+  'Politics', 'Middle East', 'Sports', 'Esports', 'Crypto',
   'Tech', 'Culture', 'World', 'Economy', 'Trump', 'Elections', 'Mentions'
 ]
 
@@ -71,6 +71,7 @@ const TAG_LABEL_TO_ID_MAP: Record<string, string> = {
   'Politics': '2',
   'Middle East': '154',
   'Sports': '1',
+  'Esports': '64',
   'Crypto': '21',
   'Tech': '1401',
   'Culture': '596',


### PR DESCRIPTION
Add 'Esports' tag (ID 64) to the market list page to enable filtering for Esports events.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b0b90cf-25d7-49f0-a6b9-cfdc7fbd34d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b0b90cf-25d7-49f0-a6b9-cfdc7fbd34d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

